### PR TITLE
Add :partial_filer as alias for :partialFilterExpression

### DIFF
--- a/lib/mongo/index/view.rb
+++ b/lib/mongo/index/view.rb
@@ -57,6 +57,7 @@ module Mongo
         :max => :max,
         :min => :min,
         :name => :name,
+        :partial_filter => :partialFilterExpression,
         :partial_filter_expression => :partialFilterExpression,
         :sparse => :sparse,
         :sphere_version => :'2dsphereIndexVersion',


### PR DESCRIPTION
A number of other keys have aliases. `:partial_filter_expression` is unreasonably long.